### PR TITLE
Return non-zero if any errors occur

### DIFF
--- a/gitrise.sh
+++ b/gitrise.sh
@@ -12,7 +12,7 @@ build_slug=""
 build_url=""
 build_status=0
 current_build_status_text=""
-exit_code=""
+exit_code=0
 log_url=""
 build_artifacts_slugs=()
 
@@ -224,7 +224,7 @@ function process_build() {
         if [[ $TESTING_ENABLED == true ]] && [[ "${FUNCNAME[1]}" != "testFailureUponReceivingHTMLREsponse" ]]; then break; fi
         sleep "$STATUS_POLLING_INTERVAL"
     done
-    if [ "$build_status" = 1 ]; then exit_code=0; else exit_code=1; fi
+    if [ "$build_status" != 1 ]; then exit_code=$(( exit_code + 1 )); fi
 } 
 
 function check_build_status() {
@@ -406,7 +406,7 @@ function download_single_artifact() {
     artifact_title=$(echo "$response" | jq ".data.title" | sed 's/"//g')
     printf "%b" "Downloading build artifact $artifact_title\n"
     curl -X GET "$artifact_url" --output "./build_artifacts/$artifact_title"
-    exit_code=$?
+    exit_code=$(( exit_code + $? ))
 }
 
 function download_build_artifacts() {

--- a/tests/download_single_artifacts_tests.sh
+++ b/tests/download_single_artifacts_tests.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+
+# shellcheck disable=SC1091,SC2155,SC2154,SC2034
+# Not following: (error message here)
+# Declare and assign separately to avoid masking return values.
+# var is referenced but not assigned.
+# var appears unused
+
+source ./gitrise.sh -T
+
+testExitCodeRemainsZeroWhenSuccessful() {
+    exit_code=0
+    # shellcheck disable=SC2317  # Don't warn about unreachable commands in this function
+    curl() {
+        return 0
+    }
+
+    download_single_artifact "some-slug" &> /dev/null
+    local expected_code=0
+    assertEquals "Status codes did not match" "$expected_code" "${exit_code}"
+}
+
+testDoesNotOverrideExistingExitCode() {
+    exit_code=1
+    # shellcheck disable=SC2317  # Don't warn about unreachable commands in this function
+    curl() {
+        return 0
+    }
+
+    download_single_artifact "some-slug" &> /dev/null
+    local expected_code=1
+    assertEquals "Status codes did not match" "$expected_code" "${exit_code}"
+}
+
+testAccumulatesErrorsOnCurlFailures() {
+    exit_code=1
+    # shellcheck disable=SC2317  # Don't warn about unreachable commands in this function
+    curl() {
+        return 1
+    }
+
+    download_single_artifact "some-slug" &> /dev/null
+    local expected_code=2
+    assertEquals "Status codes did not match" "$expected_code" "${exit_code}"
+}
+
+tearDown() {
+  build_status=0
+}
+
+. ./tests/shunit2


### PR DESCRIPTION
Builds currently succeed whenever using the `--download-artifacts` flag, because `exit_code` is overridden with the return value of `curl`.

This initiates `exit_code=0` and ensures that any errors will be accumulated to it as the build progresses. If any errors occur, either during the build or the downloading of artifacts, `exit_code` will have a non-zero value, which will ensure the script exits with an error code.