### PR TITLE
Fix logs streaming output format. Fix null exception on streaming

### DIFF
--- a/gitrise.sh
+++ b/gitrise.sh
@@ -276,7 +276,7 @@ function stream_logs() {
     fi
     [ "$DEBUG" == "true" ] && log "${command%'--header'*}" "$response" "get_log_info.log"
     # Every chunk has an accompanying position. Storing the chunks' positions to track the chunks.
-    while IFS='' read -r line; do log_chunks_positions+=("$line"); done < <(echo "$response" | jq ".log_chunks[].position")
+    while IFS='' read -r line; do log_chunks_positions+=("$line"); done < <(echo "$response" | jq ".log_chunks[]?.position // empty")
     new_log_chunck_positions=()
     for i in "${log_chunks_positions[@]}"; do
         skip=
@@ -287,7 +287,7 @@ function stream_logs() {
     done
     if [[ ${#new_log_chunck_positions[@]} != 0 ]]; then
         for i in "${new_log_chunck_positions[@]}"; do
-            parsed_chunk=$(echo "$response" | jq --arg index "$i" '.log_chunks[] | select(.position == ($index | tonumber)) | .chunk')
+            parsed_chunk=$(echo "$response" | jq -r --arg index "$i" '.log_chunks[] | select(.position == ($index | tonumber)) | .chunk')
             cleaned_chunk=$(echo "${parsed_chunk}" | sed -e 's/^"//' -e 's/"$//') 
             printf "%b" "$cleaned_chunk"
         done


### PR DESCRIPTION
I noticed that with `--stream` argument the output is unformatted as follows:
```
+------------------------------------------------------------------------------+
|                            bitrise summary: empty                            |
+---+---------------------------------------------------------------+----------+
|   | title                                                         | time (s) |
+---+---------------------------------------------------------------+----------+
| \u001b[32;1m✓\u001b[0m | \u001b[32;1mScript\u001b[0m                                                        | 2.08 sec |
+---+---------------------------------------------------------------+----------+
| \u001b[32;1m✓\u001b[0m | \u001b[32;1mDeploy to Bitrise.io - Build Artifacts, Test Reports, and P...\u001b[0m| 7.65 sec |
+---+---------------------------------------------------------------+----------+
| Total runtime: 9.73 sec                                                      |
+------------------------------------------------------------------------------+


\u001b[32;1mBitrise build successful\u001b[0m
```
And also, I'm getting `jq: error (at <stdin>:1): Cannot iterate over null (null)` once per trigger at the beginning of execution.
I assumed that's because the first log response does not contain the expected json
```
[05:13:41] REQUEST: curl --silent -X GET https://api.bitrise.io/v0.1/apps/[REDACTED]/json' 
[05:13:41] RESPONSE: {"message":"could not list build log chunks: build log not found"}

[05:13:52] REQUEST: curl --silent -X GET https://api.bitrise.io/v0.1/apps/[REDACTED]/json' 
[05:13:52] RESPONSE: {"log_chunks":[],"next_before_timestamp":"0001-01-01T00:00:00Z","next_after_timestamp":"0001-01-01T00:00:00Z","is_archived":false}
```

