### PR TITLE
Fixes Bitrise API - Missing Payload

### DIFF
--- a/gitrise.sh
+++ b/gitrise.sh
@@ -196,6 +196,7 @@ function trigger_build() {
     if [ -z "${TESTING_ENABLED}" ]; then 
         local command="curl --silent -X POST https://api.bitrise.io/v0.1/apps/$PROJECT_SLUG/builds \
                 --data '$(generate_build_payload)' \
+                --header 'Content-Type: application/json' \
                 --header 'Accept: application/json' --header 'Authorization: $ACCESS_TOKEN'"
         response=$(eval "${command}") 
     else


### PR DESCRIPTION
Adds --header 'Content-Type: application/json' to the 'trigger_build()' function that seems to now be required by Bitrise
Otherwise receiving a error of: `ERROR: null%`

Where the json response is hidden behind `-d` and shows: `{"error_msg":"Invalid request: does not contain a 'payload', or it is not a valid JSON request"}`

Fixes #65